### PR TITLE
NO JIRA issue: DOI bug, identifiers in DDM

### DIFF
--- a/docs/api/api.yml
+++ b/docs/api/api.yml
@@ -300,6 +300,8 @@ paths:
       description: |
         The client is only allowed to update the deposit from DRAFT to SUBMITTED or
         from REJECTED to DRAFT. Other state transitions will be effected by back-end processes.
+        The client must have called `GET /deposit/{id}/doi` and `PUT /deposit/{id}/metadata`
+        with all fields that are madatory at submission.
       parameters:
       - $ref: "#/components/parameters/DepositId"
       operationId: updateDepositState
@@ -313,8 +315,10 @@ paths:
       responses:
         204:
           description: Successfully updated the deposit state.
-        400:
+        400.1:
           $ref: "#/components/responses/MalformedState"
+        400.2:
+          $ref: "#/components/responses/MalformedMetadata"
         401:
           $ref: "#/components/responses/Unauthorized"
         403:

--- a/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
@@ -195,6 +195,12 @@ case class DepositDir private(baseDir: File, user: String, id: UUID) extends Deb
     _ <- maybeTriedDOI.getOrElse(writeDatasetMetadataJson(dm.setDoi(doi)))
   } yield doi
 
+  def sameDOIs(dm: DatasetMetadata): Try[Unit] = for {
+    props <- getDepositProps
+    maybeDOI = Option(props.getString("identifier.doi", null))
+    _ <- doisMatch(dm, maybeDOI)
+  } yield ()
+
   private def doisMatch(dm: DatasetMetadata, doi: Option[String]) = {
     if (doi == dm.doi) Success(())
     else {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DepositDir.scala
@@ -188,6 +188,7 @@ case class DepositDir private(baseDir: File, user: String, id: UUID) extends Deb
     maybeDOI = Option(props.getString("identifier.doi", null))
     _ <- doisMatch(dm, maybeDOI)
     maybeTriedDOI = maybeDOI.map(Success(_))
+    _ = println(s"$maybeTriedDOI $pidRequester")
     doi <- maybeTriedDOI.getOrElse(pidRequester.requestPid(PidType.doi))
     _ = props.addProperty("identifier.doi", doi)
     _ <- maybeTriedDOI.getOrElse(Try { props.save(depositPropertiesFile.toJava) })

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -61,7 +61,7 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
 
   private val uploadStagingDir = getConfiguredDirectory("deposits.stage.upload")
   private val draftsDir = getConfiguredDirectory("deposits.drafts")
-  private val submitter = new Submitter(
+  private lazy val submitter = new Submitter(
     stagingBaseDir = getConfiguredDirectory("deposits.stage"),
     submitToBaseDir = getConfiguredDirectory("deposits.submit-to"),
     pidRequester

--- a/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/EasyDepositApiApp.scala
@@ -63,8 +63,7 @@ class EasyDepositApiApp(configuration: Configuration) extends DebugEnhancedLoggi
   private val draftsDir = getConfiguredDirectory("deposits.drafts")
   private lazy val submitter = new Submitter(
     stagingBaseDir = getConfiguredDirectory("deposits.stage"),
-    submitToBaseDir = getConfiguredDirectory("deposits.submit-to"),
-    pidRequester
+    submitToBaseDir = getConfiguredDirectory("deposits.submit-to")
   )
 
   private def getConfiguredDirectory(key: String): File = {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/Submitter.scala
@@ -46,6 +46,7 @@ class Submitter(stagingBaseDir: File,
    */
   def submit(depositDir: DepositDir): Try[Unit] = {
     val propsFileName = "deposit.properties"
+    println(s"submitter: pidRequester =  $pidRequester")
     for {
       // TODO cache json read (and possibly rewritten) by getDOI and  getDatasetMetadata?
       // EASY-1464 step 3.3.1 - 3.3.3

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
@@ -91,7 +91,7 @@ object DatasetMetadata {
   )
 
   def missingValue(label: String): InvalidDocumentException = {
-    InvalidDocumentException(s"Please set $label in DatasetMetadata")
+    InvalidDocumentException("DatasetMetadata", new Exception(s"Please set $label"))
   }
 
   object PrivacySensitiveDataPresent extends Enumeration {

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetMetadata.scala
@@ -78,7 +78,7 @@ case class DatasetMetadata(identifiers: Option[Seq[SchemedValue[String]]] = None
 object DatasetMetadata {
   def apply(input: JsonInput): Try[DatasetMetadata] = input.deserialize[DatasetMetadata]
 
-  private val doiScheme = "id-type:DOI"
+  val doiScheme = "id-type:DOI"
 
   type Date = QualifiedSchemedValue[String, DateQualifier]
 

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetXml.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetXml.scala
@@ -29,6 +29,7 @@ object DatasetXml {
 
     val authors = SubmittedAuthors(dm)
     val dates = SubmittedDates(dm)
+    dm.doi.getOrElse(throwNoContentFor(s"dcterms:identifier xsi:type='${DatasetMetadata.doiScheme}'"))
 
     <ddm:DDM
       xmlns:dc="http://purl.org/dc/elements/1.1/"

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetXml.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/DatasetXml.scala
@@ -37,6 +37,7 @@ object DatasetXml {
       xmlns:dcterms="http://purl.org/dc/terms/"
       xmlns:dcx-dai="http://easy.dans.knaw.nl/schemas/dcx/dai/"
       xmlns:ddm="http://easy.dans.knaw.nl/schemas/md/ddm/"
+      xmlns:id-type="http://easy.dans.knaw.nl/schemas/vocab/identifier-type/"
       xsi:schemaLocation="http://easy.dans.knaw.nl/schemas/md/ddm/ https://easy.dans.knaw.nl/schemas/md/2017/09/ddm.xsd"
     >
       <ddm:profile>
@@ -49,6 +50,7 @@ object DatasetXml {
         { dm.accessRights.map(src => <ddm:accessRights>{ src.category.toString }</ddm:accessRights>).toSeq.mustBeNonEmpty("the accessRights") }
       </ddm:profile>
       <ddm:dcmiMetadata>
+        { dm.identifiers.getNonEmpty.map(id => <dcterms:identifier xsi:type={ id.scheme }>{ id.value }</dcterms:identifier>) }
         { dm.alternativeTitles.getNonEmpty.map(str => <dcterms:alternative>{ str }</dcterms:alternative>).addAttr(lang) }
         { authors.contributors.map(author => <dcx-dai:contributorDetails>{ authorDetails(author) }</dcx-dai:contributorDetails>) }
         { authors.rightsHolders.map(author => <dcterms:rightsHolder>{ author.toString }</dcterms:rightsHolder>) }

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/JsonUtil.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/JsonUtil.scala
@@ -33,9 +33,9 @@ import scala.util.{ Failure, Success, Try }
 
 object JsonUtil {
 
-  case class InvalidDocumentException(s: String, t: Throwable = null)
-    extends Exception(if (t == null) s"invalid $s"
-                      else s"invalid $s: ${ t.getMessage }", t)
+  case class InvalidDocumentException(document: String, t: Throwable = null)
+    extends Exception(if (t == null) s"invalid $document"
+                      else s"invalid $document: ${ t.getMessage }", t)
 
   class PathSerializer extends CustomSerializer[Path](_ =>
     ( {

--- a/src/test/resources/manual-test/datasetmetadata.json
+++ b/src/test/resources/manual-test/datasetmetadata.json
@@ -1,7 +1,7 @@
 {
   "identifiers": [
     {
-      "scheme": "doi",
+      "scheme": "id-type:DOI",
       "value": "10.17632/DANS.6wg5xccnjd.1"
     }
   ],

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetXmlSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetXmlSpec.scala
@@ -195,21 +195,21 @@ class DatasetXmlSpec extends TestSupportFixture with DdmBehavior {
   "apply" should "report a missing title" in {
     DatasetXml(minimal.copy(titles = None)) should matchPattern {
       case Failure(InvalidDocumentException(_, e)) if e.getMessage ==
-        "no content for mandatory dc:title" =>
+        "Please set a title" =>
     }
   }
 
   it should "report an empty list of titles" in {
     DatasetXml(minimal.copy(titles = Some(Seq.empty))) should matchPattern {
       case Failure(InvalidDocumentException(_, e)) if e.getMessage ==
-        "no content for mandatory dc:title" =>
+        "Please set a title" =>
     }
   }
 
   it should "report an empty string as title" in {
     DatasetXml(minimal.copy(titles = Some(Seq("   \t")))) should matchPattern {
       case Failure(InvalidDocumentException(_, e)) if e.getMessage ==
-        "no content for mandatory dc:title" =>
+        "Please set a title" =>
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetXmlSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetXmlSpec.scala
@@ -88,9 +88,6 @@ class DatasetXmlSpec extends TestSupportFixture with DdmBehavior {
         <dc:title>Lorum</dc:title>
         <dc:title>ipsum</dc:title>
       </ddm:profile>
-      <ddm:dcmiMetadata>
-        <dcterms:identifier xsi:type="id-type:DOI">mocked-DOI</dcterms:identifier>
-      </ddm:dcmiMetadata>
   )
 
   "minimal with multiple descriptions" should behave like validDatasetMetadata(

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetXmlSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetXmlSpec.scala
@@ -37,6 +37,7 @@ class DatasetXmlSpec extends TestSupportFixture with DdmBehavior {
 
   private val minimal = DatasetMetadata(
     """{
+      |  "identifiers": [{"scheme":"id-type:DOI", "value":"mocked-DOI"}],
       |  "titles": ["Lorum ipsum"],
       |  "descriptions": ["dolor"],
       |  "dates": [
@@ -213,7 +214,7 @@ class DatasetXmlSpec extends TestSupportFixture with DdmBehavior {
   }
 
   "datasetmetadata.json" should behave like validDatasetMetadata(
-    input = parseTestResource("datasetmetadata.json")
+    input = parseTestResource("datasetmetadata.json").map(_.setDoi("mocked_DOI"))
   )
   // TODO keep resources in sync with UI module: https://github.com/DANS-KNAW/easy-deposit-ui/blob/784fdc5/src/test/typescript/mockserver/metadata.ts#L246
   "datasetmetadata-from-ui-some.json" should behave like validDatasetMetadata(

--- a/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetXmlSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/docs/DatasetXmlSpec.scala
@@ -24,7 +24,7 @@ import javax.xml.transform.Source
 import javax.xml.transform.stream.StreamSource
 import javax.xml.validation.{ Schema, SchemaFactory }
 import nl.knaw.dans.easy.deposit.TestSupportFixture
-import nl.knaw.dans.easy.deposit.docs.DatasetMetadata.{ Author, DateQualifier, SchemedKeyValue }
+import nl.knaw.dans.easy.deposit.docs.DatasetMetadata.{ Author, DateQualifier, SchemedKeyValue, SchemedValue }
 import nl.knaw.dans.easy.deposit.docs.JsonUtil.InvalidDocumentException
 import nl.knaw.dans.lib.error._
 import org.xml.sax.SAXParseException
@@ -75,6 +75,7 @@ class DatasetXmlSpec extends TestSupportFixture with DdmBehavior {
         <ddm:accessRights>OPEN_ACCESS</ddm:accessRights>
       </ddm:profile>
       <ddm:dcmiMetadata>
+        <dcterms:identifier xsi:type="id-type:DOI">mocked-DOI</dcterms:identifier>
         <dcterms:dateSubmitted xsi:type="dcterms:W3CDTF">2018-03-22</dcterms:dateSubmitted>
       </ddm:dcmiMetadata>
   )
@@ -87,6 +88,9 @@ class DatasetXmlSpec extends TestSupportFixture with DdmBehavior {
         <dc:title>Lorum</dc:title>
         <dc:title>ipsum</dc:title>
       </ddm:profile>
+      <ddm:dcmiMetadata>
+        <dcterms:identifier xsi:type="id-type:DOI">mocked-DOI</dcterms:identifier>
+      </ddm:dcmiMetadata>
   )
 
   "minimal with multiple descriptions" should behave like validDatasetMetadata(
@@ -117,6 +121,7 @@ class DatasetXmlSpec extends TestSupportFixture with DdmBehavior {
     subset = actualDDM => dcmiMetadata(actualDDM),
     expectedDdmContent =
       <ddm:dcmiMetadata>
+        <dcterms:identifier xsi:type="id-type:DOI">mocked-DOI</dcterms:identifier>
         <dcterms:alternative>Lorum</dcterms:alternative>
         <dcterms:alternative>ipsum</dcterms:alternative>
         <dcterms:dateSubmitted xsi:type="dcterms:W3CDTF">2018-03-22</dcterms:dateSubmitted>
@@ -148,6 +153,7 @@ class DatasetXmlSpec extends TestSupportFixture with DdmBehavior {
       expectedDdmContent =
         //N.B: creators in ddm:profile unless they are rightsHolders
         <ddm:dcmiMetadata>
+          <dcterms:identifier xsi:type="id-type:DOI">mocked-DOI</dcterms:identifier>
           <dcterms:rightsHolder>A.S. Terix</dcterms:rightsHolder>
           <dcterms:rightsHolder>O. Belix</dcterms:rightsHolder>
           <dcterms:dateSubmitted xsi:type="dcterms:W3CDTF">2018-03-22</dcterms:dateSubmitted>
@@ -170,6 +176,7 @@ class DatasetXmlSpec extends TestSupportFixture with DdmBehavior {
         // the dateSubmitted specified above is replaced by "now" as set by the fixture
         // dateCreated and dateAvailable are documented with the pure minimal test
         <ddm:dcmiMetadata>
+          <dcterms:identifier xsi:type="id-type:DOI">mocked-DOI</dcterms:identifier>
           <dc:date xsi:type="dcterms:W3CDTF">{ date }</dc:date>
           <dcterms:dateAccepted xsi:type="dcterms:W3CDTF">{ date }</dcterms:dateAccepted>
           <dcterms:dateCopyrighted xsi:type="dcterms:W3CDTF">{ date }</dcterms:dateCopyrighted>
@@ -218,7 +225,7 @@ class DatasetXmlSpec extends TestSupportFixture with DdmBehavior {
   )
   // TODO keep resources in sync with UI module: https://github.com/DANS-KNAW/easy-deposit-ui/blob/784fdc5/src/test/typescript/mockserver/metadata.ts#L246
   "datasetmetadata-from-ui-some.json" should behave like validDatasetMetadata(
-    input = parseTestResource("datasetmetadata-from-ui-some.json")
+    input = parseTestResource("datasetmetadata-from-ui-some.json").map(_.copy(identifiers = Some(Seq(SchemedValue(DatasetMetadata.doiScheme,"mocked-doi")))))
   )
   "datasetmetadata-from-ui-all.json without one of the authors" should behave like validDatasetMetadata(
     input = parseTestResource("datasetmetadata-from-ui-all.json"),
@@ -253,6 +260,7 @@ class DatasetXmlSpec extends TestSupportFixture with DdmBehavior {
         <ddm:accessRights>OPEN_ACCESS</ddm:accessRights>
       </ddm:profile>
       <ddm:dcmiMetadata>
+        <dcterms:identifier xsi:type="id-type:DOI">doi:10.17632/DANS.6wg5xccnjd.1</dcterms:identifier>
         <dcterms:alternative xml:lang="nld">alternative title 1</dcterms:alternative>
         <dcterms:alternative xml:lang="nld">alternative title2</dcterms:alternative>
         <dcx-dai:contributorDetails>

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -20,7 +20,7 @@ import java.util.UUID
 import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidRequester
 import nl.knaw.dans.easy.deposit.PidRequesterComponent.PidType.PidType
 import nl.knaw.dans.easy.deposit.authentication.AuthenticationMocker._
-import nl.knaw.dans.easy.deposit.docs.{ DatasetMetadata, DepositInfo }
+import nl.knaw.dans.easy.deposit.docs.{ DatasetMetadata, DepositInfo, JsonUtil }
 import nl.knaw.dans.easy.deposit.{ EasyDepositApiApp, _ }
 import nl.knaw.dans.lib.error._
 import org.eclipse.jetty.http.HttpStatus._
@@ -47,9 +47,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
 
     // create dataset
     expectsUserFooBar
-    val responseBody = post(uri = s"/deposit", headers = Seq(basicAuthentication)) {
-      new String(bodyBytes)
-    }
+    val responseBody = post(uri = s"/deposit", headers = Seq(basicAuthentication)) { body }
     val uuid = DepositInfo(responseBody).map(_.id.toString).getOrRecover(e => fail(e.toString, e))
     val metadataURI = s"/deposit/$uuid/metadata"
 
@@ -115,9 +113,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
 
     // create dataset
     expectsUserFooBar
-    val responseBody = post(uri = s"/deposit", headers = Seq(basicAuthentication)) {
-      new String(bodyBytes)
-    }
+    val responseBody = post(uri = s"/deposit", headers = Seq(basicAuthentication)) { body }
     val uuid = DepositInfo(responseBody).map(_.id.toString).getOrRecover(e => fail(e.toString, e))
 
     val dataFilesBase = DepositDir(testDir / "drafts", "foo", UUID.fromString(uuid)).getDataFiles.get.bag.data
@@ -130,7 +126,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     }
 
     val expectedItem = """{"fileName":"text.txt","dirPath":"path/to/text.txt","sha1sum":"c5b8de8cc3587aef4e118a481115391033621e06"}"""
-    val expectedListItem = expectedItem.replace("/text.txt","")
+    val expectedListItem = expectedItem.replace("/text.txt", "")
 
     // get file
     expectsUserFooBar
@@ -151,9 +147,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
 
     // create dataset
     expectsUserFooBar
-    val responseBody = post(uri = s"/deposit", headers = Seq(basicAuthentication)) {
-      new String(bodyBytes)
-    }
+    val responseBody = post(uri = s"/deposit", headers = Seq(basicAuthentication)) { body }
     val uuid = DepositInfo(responseBody).map(_.id.toString).getOrRecover(e => fail(e.toString, e))
 
     // expect a new doi once
@@ -180,23 +174,13 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     val doi = Try { DatasetMetadata(datasetMetadata).get.identifiers.get.headOption.get.value }
       .getOrRecover(e => fail("could not get DOI from test input", e))
     (testDir / "easy-ingest-flow-inbox").createDirectories()
+    (testDir / "stage").createDirectories()
 
     // create dataset
     expectsUserFooBar
-    val responseBody = post(uri = s"/deposit", headers = Seq(basicAuthentication)) {
-      new String(bodyBytes)
-    }
+    val responseBody = post(uri = s"/deposit", headers = Seq(basicAuthentication)) { body }
     val uuid = DepositInfo(responseBody).map(_.id.toString).getOrRecover(e => fail(e.toString, e))
     val depositDir = testDir / "drafts" / "foo" / uuid.toString
-    val relativeTarget = "path/to/dir"
-    val absoluteTarget = depositDir / "bag/data" / relativeTarget
-    (testDir / "input").createDirectory()
-    Seq(
-      ("1.txt", "Lorem ipsum dolor sit amet"),
-      ("2.txt", "consectetur adipiscing elit"),
-      ("3.txt", "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua"),
-      ("4.txt", "Ut enim ad minim veniam")
-    ).foreach { case (name, content) => (testDir / "input" / name).write(content) }
 
     // upload dataset metadata
     expectsUserFooBar
@@ -207,7 +191,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
       status shouldBe NO_CONTENT_204
     }
 
-    // avoid having to mock the pid-service
+    // copy DOI from metadata into deposit.properties
     (depositDir / "deposit.properties").append(s"identifier.doi=$doi")
 
     // submit
@@ -223,13 +207,45 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     }
   }
 
+  s"scenario: create - ... - sumbit" should "assign the DOI at submit" in {
+    (testDir / "stage").createDirectories()
+    (testDir / "easy-ingest-flow-inbox").createDirectories()
+
+    // create dataset
+    expectsUserFooBar
+    val responseBody = post(uri = s"/deposit", headers = Seq(basicAuthentication)) { body }
+    val uuid = DepositInfo(responseBody).map(_.id.toString).getOrRecover(e => fail(e.toString, e))
+
+    // upload dataset metadata without DOI
+    expectsUserFooBar
+    put(s"/deposit/$uuid/metadata", headers = Seq(basicAuthentication),
+      body = JsonUtil.toJson(
+        DatasetMetadata(getManualTestResource("datasetmetadata-from-ui-all.json"))
+          .getOrRecover(e => fail(e))
+          .copy(identifiers = None) // no DOI
+      )
+    ) {
+      body shouldBe ""
+      status shouldBe NO_CONTENT_204
+    }
+    println(s"pidRequester = ${ app.pidRequester }")
+
+    (app.pidRequester.requestPid(_: PidType)) expects * once() returning Success("mocked-doi")
+    // submit
+    expectsUserFooBar
+    put(s"/deposit/$uuid/state", headers = Seq(basicAuthentication),
+      body = """{"state":"SUBMITTED","stateDescription":"blabla"}"""
+    ) {
+      body shouldBe ""
+      status shouldBe NO_CONTENT_204
+    }
+  }
+
   s"scenario: POST /deposit; hack state to ARCHIVED; SUBMIT" should "reject state transition" in {
 
     // create dataset
     expectsUserFooBar
-    val responseBody = post(uri = s"/deposit", headers = Seq(basicAuthentication)) {
-      new String(bodyBytes)
-    }
+    val responseBody = post(uri = s"/deposit", headers = Seq(basicAuthentication)) { body }
     val uuid = DepositInfo(responseBody).map(_.id.toString).getOrRecover(e => fail(e.toString, e))
 
     // hack state
@@ -247,9 +263,5 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
 
     // submit did not complain about missing metadata, so the state transition check indeed came first
     (testDir / "drafts" / "foo" / uuid.toString / "bag" / "metatada") shouldNot exist
-  }
-
-  private def randomContent(times: Int) = {
-    (0 until times).map(_ => UUID.randomUUID().toString).mkString("\n")
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/servlets/IntegrationSpec.scala
@@ -235,7 +235,7 @@ class IntegrationSpec extends TestSupportFixture with ServletFixture with Scalat
     put(s"/deposit/$uuid/state", headers = Seq(basicAuthentication),
       body = """{"state":"SUBMITTED","stateDescription":"blabla"}"""
     ) {
-      body shouldBe "Bad Request. invalid DatasetMetadata: no content for mandatory dcterms:identifier xsi:type='id-type:DOI'"
+      body shouldBe "Bad Request. invalid DatasetMetadata: Please first GET a DOI for this deposit"
       status shouldBe BAD_REQUEST_400
     }
   }


### PR DESCRIPTION
The UI does not see that a failing submit may have assigned a DOI. Thus the next submit attempt fails because the DOI gets erased in the `metadata/dataset.json` while still present in the `deposit.properties`.

Rather than going through complex error handling and roll-back problems, the UI should go through the following steps when a user pushes the submit button:
* GET the DOI if not done by the user before
* PUT the metadata with the generated DOI
* PUT the new state

#### When applied
* The api will no longer assign a DOI on submit. In stead the api will fail if it the DOI missing.
* Copy the identifiers from json to DDM
* Give more json centric error messages on missing fields

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

See `src/test/resources/manual-test`

#### Related pull requests on github
if  #2 is merged, the PR on blessed can be created. This PR is a sneak preview.
