### PR TITLE
EASY-2258 (review): propose a better order for the files

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.deposit/DataFiles.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/DataFiles.scala
@@ -26,7 +26,7 @@ import nl.knaw.dans.easy.deposit.docs.FileInfo
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 
 import scala.language.postfixOps
-import Ordering._
+import scala.collection.JavaConverters._
 import scala.util.{ Failure, Success, Try }
 
 /**
@@ -70,7 +70,7 @@ case class DataFiles(bag: DansBag) extends DebugEnhancedLogging {
         .withFilter(_._1.isChildOf(parentPath))
         .map((toFileInfo _).tupled)
         .toSeq
-        .sortBy(fileInfo => s"${fileInfo.dirpath}/${fileInfo.filename}")
+        .sortBy(fileInfo => (fileInfo.dirpath.asScala, fileInfo.filename))
     }
 
     manifestMap

--- a/src/main/scala/nl.knaw.dans.easy.deposit/docs/FileInfo.scala
+++ b/src/main/scala/nl.knaw.dans.easy.deposit/docs/FileInfo.scala
@@ -24,6 +24,4 @@ import java.nio.file.Path
  * @param dirpath  path of the containing directory, relative to the content base directory
  * @param sha1sum  the SHA-1 checksum of the file data
  */
-case class FileInfo(filename: String, dirpath: Path, sha1sum: String) extends Ordered[FileInfo] {
-  override def compare(that: FileInfo): Int = s"${this.dirpath}/$filename".compareTo(s"${that.dirpath}/$filename")
-}
+case class FileInfo(filename: String, dirpath: Path, sha1sum: String)

--- a/src/test/scala/nl.knaw.dans.easy.deposit/DataFilesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/DataFilesSpec.scala
@@ -111,17 +111,20 @@ class DataFilesSpec extends TestSupportFixture {
       .addPayloadFile(randomContent, Paths.get("folder11/4.txt")).getOrRecover(payloadFailure)
       .addPayloadFile(randomContent, Paths.get("folder1/5.txt")).getOrRecover(payloadFailure)
     bag.save()
-    DataFiles(bag).list(Paths.get(""))
-      .map(_.map(fileInfo => s"${ fileInfo.dirpath }/${ fileInfo.filename }")) shouldBe Success(List(
-      "#/1.txt",
-      "/1.txt",
-      "folder1#b/x.txt",
-      "folder1/3.txt",
-      "folder1/5.txt",
-      "folder1/b/x.txt",
-      "folder11/4.txt",
-      "folder2/4.txt"
-    ))
+    
+    inside(DataFiles(bag).list(Paths.get(""))) {
+      case Success(result) =>
+        result.map(fileInfo => fileInfo.dirpath.toString -> fileInfo.filename) should contain inOrderOnly(
+          "" -> "1.txt",
+          "#" -> "1.txt",
+          "folder1" -> "3.txt",
+          "folder1" -> "5.txt",
+          "folder1/b" -> "x.txt",
+          "folder1#b" -> "x.txt",
+          "folder11" -> "4.txt",
+          "folder2" -> "4.txt",
+        )
+    }
   }
 
   "fileInfo" should "contain proper information about the files" in {

--- a/src/test/scala/nl.knaw.dans.easy.deposit/DataFilesSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.deposit/DataFilesSpec.scala
@@ -111,20 +111,17 @@ class DataFilesSpec extends TestSupportFixture {
       .addPayloadFile(randomContent, Paths.get("folder11/4.txt")).getOrRecover(payloadFailure)
       .addPayloadFile(randomContent, Paths.get("folder1/5.txt")).getOrRecover(payloadFailure)
     bag.save()
-    
-    inside(DataFiles(bag).list(Paths.get(""))) {
-      case Success(result) =>
-        result.map(fileInfo => fileInfo.dirpath.toString -> fileInfo.filename) should contain inOrderOnly(
-          "" -> "1.txt",
-          "#" -> "1.txt",
-          "folder1" -> "3.txt",
-          "folder1" -> "5.txt",
-          "folder1/b" -> "x.txt",
-          "folder1#b" -> "x.txt",
-          "folder11" -> "4.txt",
-          "folder2" -> "4.txt",
-        )
-    }
+
+    DataFiles(bag).list(Paths.get("")).map(_.map(fileInfo => fileInfo.dirpath.toString -> fileInfo.filename)) shouldBe Success(List(
+      "" -> "1.txt",
+      "#" -> "1.txt",
+      "folder1" -> "3.txt",
+      "folder1" -> "5.txt",
+      "folder1/b" -> "x.txt",
+      "folder1#b" -> "x.txt",
+      "folder11" -> "4.txt",
+      "folder2" -> "4.txt",
+    ))
   }
 
   "fileInfo" should "contain proper information about the files" in {


### PR DESCRIPTION
I propose another order, where `/a/foo.txt` should come before `/a/b/bar.txt` and `/a/b/bar.txt` should come before `/b/bar.txt`.

@jo-pol what do you think? I set this PR up such that you can merge it into your PR and further improve from there. 